### PR TITLE
fix: 画像アップロード前に圧縮

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -17,6 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "axios": "^1.7.7",
+    "browser-image-compression": "^2.0.2",
     "cloudinary": "^2.5.1",
     "framer-motion": "^11.11.7",
     "next": "14.2.14",

--- a/next/src/actions/uploadImageAction.ts
+++ b/next/src/actions/uploadImageAction.ts
@@ -16,6 +16,7 @@ export async function uploadImageAction(
   const options = {
     folder: folder_name,
     public_id,
+    format: 'webp',
   }
   return await cloudinary.uploader.upload(fileData, options)
 }

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -2727,6 +2727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-image-compression@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "browser-image-compression@npm:2.0.2"
+  dependencies:
+    uzip: "npm:0.20201231.0"
+  checksum: 10c0/32be07f8849f2de501a71f6dd07e691c085fc7a2055456eb120fe5d765e3fcf7de00696915a8d614527d4df10f34c31526304b7d18aae036bb1c58d801e3fcbd
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.23.3, browserslist@npm:^4.24.0":
   version: 4.24.0
   resolution: "browserslist@npm:4.24.0"
@@ -5699,6 +5708,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.8.1"
     "@typescript-eslint/parser": "npm:^8.8.1"
     axios: "npm:^1.7.7"
+    browser-image-compression: "npm:^2.0.2"
     cloudinary: "npm:^2.5.1"
     eslint: "npm:^8"
     eslint-config-next: "npm:14.2.14"
@@ -6229,6 +6239,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/23b1597c10adf15b26ade9e8c318d8cc0abc9ec0ab5fc7ca7338da92e89c2536abd150a5891bf076836c352fdfa104fc7231fb48f806fd9960e0cbe03601abaf
+  languageName: node
+  linkType: hard
+
+"uzip@npm:0.20201231.0":
+  version: 0.20201231.0
+  resolution: "uzip@npm:0.20201231.0"
+  checksum: 10c0/44b261b20ac7e4d71e7099d7a7c4885626044be61cd246e76cf548fa444a4a37c301d1a683679168bc29c91d2ec81d62b8c1c75217a26b37f6ce35223866c2d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 対応内容
- [ ] 画像アップロード前に圧縮する
- [ ] browser-image-compressionの導入（仮）
- [ ] webpに変換

### 残タスク
- [ ] sharpなどのサーバーコンポーネント側で画像を圧縮しwebpに変換できるようにする（本リリース）
- [ ] 上限の画像サイズを決める