### PR TITLE
feat: メール変更機能の追加

### DIFF
--- a/next/src/actions/changeEmailAction.ts
+++ b/next/src/actions/changeEmailAction.ts
@@ -22,7 +22,7 @@ export async function changeEmailAction(
   }
 
   const new_email = formData.get('new_email')
-  const password = formData.get('password')
+  const current_password = formData.get('current_password')
 
   const tokens = await getUserTokens()
   if (!tokens) {
@@ -43,12 +43,13 @@ export async function changeEmailAction(
       },
       body: JSON.stringify({
         email: new_email,
-        // password,
+        current_password,
       }),
     })
 
     const data = await res.json()
 
+    console.log(data)
     if (!res.ok) {
       return submission.reply({
         formErrors: data.errors.full_messages || [

--- a/next/src/actions/changeEmailAction.ts
+++ b/next/src/actions/changeEmailAction.ts
@@ -4,25 +4,25 @@
 
 import { parseWithZod } from '@conform-to/zod'
 import { revalidatePath } from 'next/cache'
-import { uploadImageAction } from './uploadImageAction'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
-import { changeProfileSchema } from '@/schemas/userSchema'
+import { changeEmailSchema } from '@/schemas/userSchema'
 import { getUserTokens } from '@/utils/getUserTokens'
 
-export async function changeProfileAction(
+export async function changeEmailAction(
   prevState: unknown,
   formData: FormData,
 ) {
+  const currentEmail = formData.get('current_email') as string
   const submission = parseWithZod(formData, {
-    schema: changeProfileSchema,
+    schema: changeEmailSchema(currentEmail),
   })
 
   if (submission.status !== 'success') {
     return submission.reply()
   }
 
-  const nickname = formData.get('nickname')
-  const imageFile = formData.get('image') ? String(formData.get('image')) : ''
+  const new_email = formData.get('new_email')
+  const password = formData.get('password')
 
   const tokens = await getUserTokens()
   if (!tokens) {
@@ -32,12 +32,6 @@ export async function changeProfileAction(
   }
 
   try {
-    let image_url = null
-    if (imageFile) {
-      // 画像をCloudinaryにアップロード
-      const uploadResult = await uploadImageAction(imageFile, 'profile')
-      image_url = uploadResult.secure_url
-    }
 
     const res = await fetch(`${apiBaseUrl}/auth`, {
       method: 'PATCH',
@@ -48,8 +42,8 @@ export async function changeProfileAction(
         uid: tokens.uid,
       },
       body: JSON.stringify({
-        nickname,
-        image: image_url,
+        email: new_email,
+        // password,
       }),
     })
 

--- a/next/src/actions/changeEmailAction.ts
+++ b/next/src/actions/changeEmailAction.ts
@@ -3,10 +3,10 @@
 'use server'
 
 import { parseWithZod } from '@conform-to/zod'
-import { revalidatePath } from 'next/cache'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
 import { changeEmailSchema } from '@/schemas/userSchema'
 import { getUserTokens } from '@/utils/getUserTokens'
+import { revalidatePath } from 'next/cache'
 
 export async function changeEmailAction(
   prevState: unknown,
@@ -49,7 +49,6 @@ export async function changeEmailAction(
 
     const data = await res.json()
 
-    console.log(data)
     if (!res.ok) {
       return submission.reply({
         formErrors: data.errors.full_messages || [
@@ -58,7 +57,7 @@ export async function changeEmailAction(
       })
     }
 
-    revalidatePath('/setting/profile')
+    revalidatePath('/setting/email')
     return submission.reply()
   } catch (error: any) {
     return submission.reply({

--- a/next/src/actions/changeEmailAction.ts
+++ b/next/src/actions/changeEmailAction.ts
@@ -3,10 +3,10 @@
 'use server'
 
 import { parseWithZod } from '@conform-to/zod'
+import { revalidatePath } from 'next/cache'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
 import { changeEmailSchema } from '@/schemas/userSchema'
 import { getUserTokens } from '@/utils/getUserTokens'
-import { revalidatePath } from 'next/cache'
 
 export async function changeEmailAction(
   prevState: unknown,
@@ -32,7 +32,6 @@ export async function changeEmailAction(
   }
 
   try {
-
     const res = await fetch(`${apiBaseUrl}/auth`, {
       method: 'PATCH',
       headers: {

--- a/next/src/actions/confirmUserAction.ts
+++ b/next/src/actions/confirmUserAction.ts
@@ -50,24 +50,17 @@ export async function confirmUserAction(
       return { message: data.message, status: 'error' }
     }
 
-    // ユーザー登録時は自動ログイン（それ以外はログアウト）
-    if(requestAction === 'registration') {
-      const accessToken = data.access_token
-      const client = data.client
-      const uid = data.uid
+    const accessToken = data.access_token
+    const client = data.client
+    const uid = data.uid
 
-      if (accessToken && client && uid) {
-        await setAccessTokenAction(accessToken, client, uid)
-      } else {
-        return {
-          message:
-            'サーバーエラーが発生しました。時間をおいてから再度お試しください。',
-          status: 'error',
-        }
-      }
+    if (accessToken && client && uid) {
+      await setAccessTokenAction(accessToken, client, uid)
     } else {
-      if(user.isSignedIn) {
-        await signoutAction()
+      return {
+        message:
+          'サーバーエラーが発生しました。時間をおいてから再度お試しください。',
+        status: 'error',
       }
     }
 

--- a/next/src/actions/confirmUserAction.ts
+++ b/next/src/actions/confirmUserAction.ts
@@ -4,9 +4,8 @@
 
 import { setAccessTokenAction } from './setAccessTokenAction'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
-import { fetchUserState } from '@/utils/fetchUserState'
-import { signoutAction } from './signoutAction'
 import { UserRequestType } from '@/types/types'
+import { fetchUserState } from '@/utils/fetchUserState'
 
 type ConfirmUserActionResult = {
   message: string
@@ -15,7 +14,7 @@ type ConfirmUserActionResult = {
 
 export async function confirmUserAction(
   confirmationToken: string,
-  requestAction: UserRequestType
+  requestAction: UserRequestType,
 ): Promise<ConfirmUserActionResult> {
   const user = await fetchUserState()
 

--- a/next/src/actions/confirmUserAction.ts
+++ b/next/src/actions/confirmUserAction.ts
@@ -5,6 +5,8 @@
 import { setAccessTokenAction } from './setAccessTokenAction'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
 import { fetchUserState } from '@/utils/fetchUserState'
+import { signoutAction } from './signoutAction'
+import { UserRequestType } from '@/types/types'
 
 type ConfirmUserActionResult = {
   message: string
@@ -13,16 +15,17 @@ type ConfirmUserActionResult = {
 
 export async function confirmUserAction(
   confirmationToken: string,
+  requestAction: UserRequestType
 ): Promise<ConfirmUserActionResult> {
   const user = await fetchUserState()
 
   // トークンなしの場合
-  if (!confirmationToken) {
+  if (!confirmationToken || !requestAction) {
     return { message: 'URLが有効ではありません。', status: 'error' }
   }
 
   // ログイン済みの場合
-  if (user.isSignedIn) {
+  if (user.isSignedIn && requestAction === 'registration') {
     return {
       message:
         'すでに別のアカウントでログイン済みです。ログアウトしてから再度アクセスしてください。',
@@ -36,7 +39,9 @@ export async function confirmUserAction(
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ confirmation_token: confirmationToken }),
+      body: JSON.stringify({
+        confirmation_token: confirmationToken,
+      }),
     })
 
     const data = await res.json()
@@ -45,20 +50,28 @@ export async function confirmUserAction(
       return { message: data.message, status: 'error' }
     }
 
-    const accessToken = data.access_token
-    const client = data.client
-    const uid = data.uid
+    // ユーザー登録時は自動ログイン（それ以外はログアウト）
+    if(requestAction === 'registration') {
+      const accessToken = data.access_token
+      const client = data.client
+      const uid = data.uid
 
-    if (accessToken && client && uid) {
-      await setAccessTokenAction(accessToken, client, uid)
-      return { message: data.message, status: 'success' }
+      if (accessToken && client && uid) {
+        await setAccessTokenAction(accessToken, client, uid)
+      } else {
+        return {
+          message:
+            'サーバーエラーが発生しました。時間をおいてから再度お試しください。',
+          status: 'error',
+        }
+      }
     } else {
-      return {
-        message:
-          'サーバーエラーが発生しました。時間をおいてから再度お試しください。',
-        status: 'error',
+      if(user.isSignedIn) {
+        await signoutAction()
       }
     }
+
+    return { message: data.message, status: 'success' }
   } catch (error: any) {
     return {
       message:

--- a/next/src/actions/signoutAction.ts
+++ b/next/src/actions/signoutAction.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 
 export async function signoutAction() {
   const cookieStore = await cookies()
@@ -9,6 +8,4 @@ export async function signoutAction() {
   cookieStore.delete('access-token')
   cookieStore.delete('client')
   cookieStore.delete('uid')
-
-  redirect('/')
 }

--- a/next/src/app/confirmation/page.tsx
+++ b/next/src/app/confirmation/page.tsx
@@ -41,7 +41,7 @@ export default async function Confirmation({
       >
         <Spinner size="xl" speed="0.8s" thickness="4px" color="brand.primary" />
         <Text fontWeight="bold" fontSize="lg">
-          ユーザー認証中です
+          メールアドレスを認証中です
         </Text>
       </VStack>
       <ConfirmationHandler confirmationToken={confirmationToken} requestAction={requestAction} />

--- a/next/src/app/confirmation/page.tsx
+++ b/next/src/app/confirmation/page.tsx
@@ -2,6 +2,7 @@ import { Spinner, VStack, Text } from '@chakra-ui/react'
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import ConfirmationHandler from '../features/user/ConfirmationHandler'
+import { UserRequestType } from '@/types/types'
 
 export const metadata: Metadata = {
   title: 'ユーザー認証中 | Bon Voyage Collcection',
@@ -15,6 +16,7 @@ export const metadata: Metadata = {
 type ConfirmationProps = {
   searchParams: {
     confirmation_token: string
+    request_action: UserRequestType
   }
 }
 
@@ -26,6 +28,7 @@ export default async function Confirmation({
   }
 
   const confirmationToken = searchParams.confirmation_token
+  const requestAction = searchParams.request_action
 
   return (
     <>
@@ -41,7 +44,7 @@ export default async function Confirmation({
           ユーザー認証中です
         </Text>
       </VStack>
-      <ConfirmationHandler confirmationToken={confirmationToken} />
+      <ConfirmationHandler confirmationToken={confirmationToken} requestAction={requestAction} />
     </>
   )
 }

--- a/next/src/app/confirmation/page.tsx
+++ b/next/src/app/confirmation/page.tsx
@@ -5,8 +5,8 @@ import ConfirmationHandler from '../features/user/ConfirmationHandler'
 import { UserRequestType } from '@/types/types'
 
 export const metadata: Metadata = {
-  title: 'ユーザー認証中 | Bon Voyage Collcection',
-  description: 'ユーザー認証中です。',
+  title: 'メールアドレス認証中 | Bon Voyage Collcection',
+  description: 'メールアドレス認証中です。',
   keywords: '',
   robots: {
     index: false,
@@ -44,7 +44,10 @@ export default async function Confirmation({
           メールアドレスを認証中です
         </Text>
       </VStack>
-      <ConfirmationHandler confirmationToken={confirmationToken} requestAction={requestAction} />
+      <ConfirmationHandler
+        confirmationToken={confirmationToken}
+        requestAction={requestAction}
+      />
     </>
   )
 }

--- a/next/src/app/features/favorite/GlobalStateSetter.tsx
+++ b/next/src/app/features/favorite/GlobalStateSetter.tsx
@@ -8,10 +8,10 @@ import {
   useFavoriteStore,
   useMyPostsStore,
 } from '@/store/store'
-import { PostType, SouvenirCardType, UserType } from '@/types/types'
+import { PostType, SouvenirCardType, CurrentUserType } from '@/types/types'
 
 type GlobalStateSetterProps = {
-  userData: UserType
+  userData: CurrentUserType
   favoritedSouvenirsData: Array<SouvenirCardType>
   myPostsData: Array<PostType>
 }

--- a/next/src/app/features/setting/DeleteUserModalWithButton.tsx
+++ b/next/src/app/features/setting/DeleteUserModalWithButton.tsx
@@ -13,11 +13,11 @@ import {
   AlertDialogBody,
   useToast,
 } from '@chakra-ui/react'
+import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { deleteUserAction } from '@/actions/deleteUserAction'
 import { signoutAction } from '@/actions/signoutAction'
 import CustomIcon from '@/components/atoms/CustomIcon'
-import { redirect, useRouter } from 'next/navigation'
 
 const DeleteUserModalWithButton = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false)

--- a/next/src/app/features/setting/DeleteUserModalWithButton.tsx
+++ b/next/src/app/features/setting/DeleteUserModalWithButton.tsx
@@ -17,10 +17,12 @@ import { useRef, useState } from 'react'
 import { deleteUserAction } from '@/actions/deleteUserAction'
 import { signoutAction } from '@/actions/signoutAction'
 import CustomIcon from '@/components/atoms/CustomIcon'
+import { redirect, useRouter } from 'next/navigation'
 
 const DeleteUserModalWithButton = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const toast = useToast()
+  const router = useRouter()
 
   // アラート
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -40,6 +42,7 @@ const DeleteUserModalWithButton = () => {
 
       if (result.status === 'success') {
         await signoutAction()
+        router.push('/sign_in')
       } else {
         onClose()
       }

--- a/next/src/app/features/user/ConfirmationHandler.tsx
+++ b/next/src/app/features/user/ConfirmationHandler.tsx
@@ -8,19 +8,21 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { confirmUserAction } from '@/actions/confirmUserAction'
 import { favoriteBulkAction } from '@/actions/favoriteBulkAction'
+import { UserRequestType } from '@/types/types'
 
-type ToastDataType = {
+type ConfirmationHandlerType = {
   confirmationToken: string
+  requestAction: UserRequestType
 }
 
-const ConfirmationHandler = ({ confirmationToken }: ToastDataType) => {
+const ConfirmationHandler = ({ confirmationToken, requestAction }: ConfirmationHandlerType) => {
   const toast = useToast()
   const router = useRouter()
 
   useEffect(() => {
     const confirmationAction = async () => {
       try {
-        const result = await confirmUserAction(confirmationToken)
+        const result = await confirmUserAction(confirmationToken, requestAction)
         toast({
           title: result.message,
           status: result.status,
@@ -52,7 +54,11 @@ const ConfirmationHandler = ({ confirmationToken }: ToastDataType) => {
           isClosable: true,
         })
       } finally {
-        router.push('/timeline')
+        if(requestAction === "registration") {
+          router.push('/timeline')
+        } else {
+          router.push('/sign_in')
+        }
       }
     }
 

--- a/next/src/app/features/user/ConfirmationHandler.tsx
+++ b/next/src/app/features/user/ConfirmationHandler.tsx
@@ -15,7 +15,10 @@ type ConfirmationHandlerType = {
   requestAction: UserRequestType
 }
 
-const ConfirmationHandler = ({ confirmationToken, requestAction }: ConfirmationHandlerType) => {
+const ConfirmationHandler = ({
+  confirmationToken,
+  requestAction,
+}: ConfirmationHandlerType) => {
   const toast = useToast()
   const router = useRouter()
 
@@ -54,7 +57,7 @@ const ConfirmationHandler = ({ confirmationToken, requestAction }: ConfirmationH
           isClosable: true,
         })
       } finally {
-        if(requestAction === "registration") {
+        if (requestAction === 'registration') {
           router.push('/timeline')
         } else {
           router.push('/mypage')

--- a/next/src/app/features/user/ConfirmationHandler.tsx
+++ b/next/src/app/features/user/ConfirmationHandler.tsx
@@ -57,7 +57,7 @@ const ConfirmationHandler = ({ confirmationToken, requestAction }: ConfirmationH
         if(requestAction === "registration") {
           router.push('/timeline')
         } else {
-          router.push('/sign_in')
+          router.push('/mypage')
         }
       }
     }

--- a/next/src/app/setting/email/page.tsx
+++ b/next/src/app/setting/email/page.tsx
@@ -1,8 +1,8 @@
-import { Box, Heading, HStack, Stack, Text } from '@chakra-ui/react'
+import { Heading, HStack, Stack, Text } from '@chakra-ui/react'
 import { Metadata } from 'next'
-import ChangeProfileForm from '@/components/organisms/form/ChangeProfileForm'
 import { checkLoginStatus } from '@/utils/checkLoginStatus'
 import ChangeEmailForm from '@/components/organisms/form/ChangeEmailForm'
+import TextIconLink from '@/components/molecules/TextIconLink'
 
 export const metadata: Metadata = {
   title: 'メールアドレス変更｜アカウント設定 | Bon Voyage Collcection',
@@ -14,8 +14,8 @@ export default async function SignIn() {
   const user = await checkLoginStatus()
 
   return (
-    <Box maxW="660px" mx="auto">
-      <HStack mb={6}>
+    <Stack maxW="660px" mx="auto" spacing={6}>
+      <HStack>
         <Heading as="h1">メールアドレス変更</Heading>
       </HStack>
       <Stack spacing={6}>
@@ -25,6 +25,13 @@ export default async function SignIn() {
         </Stack>
         <ChangeEmailForm email={user.email}/>
       </Stack>
-    </Box>
+      <TextIconLink
+        iconPosition="left"
+        iconName="FaChevronLeft"
+        href="/setting"
+      >
+        戻る
+      </TextIconLink>
+    </Stack>
   )
 }

--- a/next/src/app/setting/email/page.tsx
+++ b/next/src/app/setting/email/page.tsx
@@ -1,8 +1,8 @@
 import { Heading, HStack, Stack, Text } from '@chakra-ui/react'
 import { Metadata } from 'next'
-import { checkLoginStatus } from '@/utils/checkLoginStatus'
-import ChangeEmailForm from '@/components/organisms/form/ChangeEmailForm'
 import TextIconLink from '@/components/molecules/TextIconLink'
+import ChangeEmailForm from '@/components/organisms/form/ChangeEmailForm'
+import { checkLoginStatus } from '@/utils/checkLoginStatus'
 
 export const metadata: Metadata = {
   title: 'メールアドレス変更｜アカウント設定 | Bon Voyage Collcection',
@@ -23,7 +23,7 @@ export default async function SignIn() {
           <Text fontWeight="bold">現在のメールアドレス</Text>
           <Text>{user.email}</Text>
         </Stack>
-        <ChangeEmailForm email={user.email}/>
+        <ChangeEmailForm email={user.email} />
       </Stack>
       <TextIconLink
         iconPosition="left"

--- a/next/src/app/setting/email/page.tsx
+++ b/next/src/app/setting/email/page.tsx
@@ -1,0 +1,30 @@
+import { Box, Heading, HStack, Stack, Text } from '@chakra-ui/react'
+import { Metadata } from 'next'
+import ChangeProfileForm from '@/components/organisms/form/ChangeProfileForm'
+import { checkLoginStatus } from '@/utils/checkLoginStatus'
+import ChangeEmailForm from '@/components/organisms/form/ChangeEmailForm'
+
+export const metadata: Metadata = {
+  title: 'メールアドレス変更｜アカウント設定 | Bon Voyage Collcection',
+  description: 'メールアドレスの変更が可能です。',
+  keywords: '',
+}
+
+export default async function SignIn() {
+  const user = await checkLoginStatus()
+
+  return (
+    <Box maxW="660px" mx="auto">
+      <HStack mb={6}>
+        <Heading as="h1">メールアドレス変更</Heading>
+      </HStack>
+      <Stack spacing={6}>
+        <Stack spacing={2}>
+          <Text fontWeight="bold">現在のメールアドレス</Text>
+          <Text>{user.email}</Text>
+        </Stack>
+        <ChangeEmailForm email={user.email}/>
+      </Stack>
+    </Box>
+  )
+}

--- a/next/src/app/setting/page.tsx
+++ b/next/src/app/setting/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import DeleteUserModalWithButton from '../features/setting/DeleteUserModalWithButton'
 import SettingLink from '../features/setting/SettingLink'
 import { checkLoginStatus } from '@/utils/checkLoginStatus'
+import TextIconLink from '@/components/molecules/TextIconLink'
 
 export const metadata: Metadata = {
   title: 'アカウント設定 | Bon Voyage Collcection',
@@ -41,6 +42,13 @@ export default async function Setting() {
         />
         <DeleteUserModalWithButton />
       </Stack>
+      <TextIconLink
+        iconPosition="left"
+        iconName="FaChevronLeft"
+        href="/mypage"
+      >
+        マイページに戻る
+      </TextIconLink>
     </Stack>
   )
 }

--- a/next/src/app/setting/page.tsx
+++ b/next/src/app/setting/page.tsx
@@ -2,8 +2,8 @@ import { Heading, HStack, Stack } from '@chakra-ui/react'
 import { Metadata } from 'next'
 import DeleteUserModalWithButton from '../features/setting/DeleteUserModalWithButton'
 import SettingLink from '../features/setting/SettingLink'
-import { checkLoginStatus } from '@/utils/checkLoginStatus'
 import TextIconLink from '@/components/molecules/TextIconLink'
+import { checkLoginStatus } from '@/utils/checkLoginStatus'
 
 export const metadata: Metadata = {
   title: 'アカウント設定 | Bon Voyage Collcection',
@@ -42,11 +42,7 @@ export default async function Setting() {
         />
         <DeleteUserModalWithButton />
       </Stack>
-      <TextIconLink
-        iconPosition="left"
-        iconName="FaChevronLeft"
-        href="/mypage"
-      >
+      <TextIconLink iconPosition="left" iconName="FaChevronLeft" href="/mypage">
         マイページに戻る
       </TextIconLink>
     </Stack>

--- a/next/src/app/setting/profile/page.tsx
+++ b/next/src/app/setting/profile/page.tsx
@@ -1,7 +1,8 @@
-import { Box, Heading, HStack } from '@chakra-ui/react'
+import { Box, Heading, HStack, Stack } from '@chakra-ui/react'
 import { Metadata } from 'next'
 import ChangeProfileForm from '@/components/organisms/form/ChangeProfileForm'
 import { checkLoginStatus } from '@/utils/checkLoginStatus'
+import TextIconLink from '@/components/molecules/TextIconLink'
 
 export const metadata: Metadata = {
   title: 'プロフィール変更｜アカウント設定 | Bon Voyage Collcection',
@@ -13,11 +14,18 @@ export default async function ChangeProfile() {
   const user = await checkLoginStatus()
 
   return (
-    <Box maxW="660px" mx="auto">
-      <HStack mb={6}>
+    <Stack maxW="660px" mx="auto" spacing={6}>
+      <HStack>
         <Heading as="h1">プロフィール変更</Heading>
       </HStack>
       <ChangeProfileForm nickname={user.nickname} image={user.image} />
-    </Box>
+      <TextIconLink
+        iconPosition="left"
+        iconName="FaChevronLeft"
+        href="/setting"
+      >
+        戻る
+      </TextIconLink>
+    </Stack>
   )
 }

--- a/next/src/app/setting/profile/page.tsx
+++ b/next/src/app/setting/profile/page.tsx
@@ -1,8 +1,8 @@
-import { Box, Heading, HStack, Stack } from '@chakra-ui/react'
+import { Heading, HStack, Stack } from '@chakra-ui/react'
 import { Metadata } from 'next'
+import TextIconLink from '@/components/molecules/TextIconLink'
 import ChangeProfileForm from '@/components/organisms/form/ChangeProfileForm'
 import { checkLoginStatus } from '@/utils/checkLoginStatus'
-import TextIconLink from '@/components/molecules/TextIconLink'
 
 export const metadata: Metadata = {
   title: 'プロフィール変更｜アカウント設定 | Bon Voyage Collcection',

--- a/next/src/app/setting/profile/page.tsx
+++ b/next/src/app/setting/profile/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   keywords: '',
 }
 
-export default async function SignIn() {
+export default async function ChangeProfile() {
   const user = await checkLoginStatus()
 
   return (

--- a/next/src/components/atoms/SignoutButton.tsx
+++ b/next/src/components/atoms/SignoutButton.tsx
@@ -4,12 +4,14 @@ import { Button } from '@chakra-ui/react'
 import CustomIcon from './CustomIcon'
 import { signoutAction } from '@/actions/signoutAction'
 import { useFavoriteStore } from '@/store/store'
+import { redirect } from 'next/navigation'
 
 const SignoutButton = () => {
   const { setFavoritedSouvenirs } = useFavoriteStore()
   const handleSignout = () => {
     setFavoritedSouvenirs([])
     signoutAction()
+    redirect('/sign_in')
 
     // おすすめのお土産の一時データをリセット
     localStorage.removeItem('favoritedSouvenirs')

--- a/next/src/components/atoms/SignoutButton.tsx
+++ b/next/src/components/atoms/SignoutButton.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Button } from '@chakra-ui/react'
+import { redirect } from 'next/navigation'
 import CustomIcon from './CustomIcon'
 import { signoutAction } from '@/actions/signoutAction'
 import { useFavoriteStore } from '@/store/store'
-import { redirect } from 'next/navigation'
 
 const SignoutButton = () => {
   const { setFavoritedSouvenirs } = useFavoriteStore()

--- a/next/src/components/organisms/form/ChangeEmailForm.tsx
+++ b/next/src/components/organisms/form/ChangeEmailForm.tsx
@@ -1,15 +1,25 @@
+/* eslint react-hooks/exhaustive-deps: 0 */
+
 'use client'
 
-import { Alert, AlertDescription, AlertIcon, Input, Stack, Text, useToast } from '@chakra-ui/react'
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Input,
+  Stack,
+  Text,
+  useToast,
+} from '@chakra-ui/react'
 import { useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
+import { redirect } from 'next/navigation'
+import { useEffect } from 'react'
 import { useFormState } from 'react-dom'
 import SubmitButton from '../../atoms/SubmitButton'
 import InputWithLabel from '../../molecules/InputWithLabel'
-import { changeEmailSchema } from '@/schemas/userSchema'
 import { changeEmailAction } from '@/actions/changeEmailAction'
-import { useEffect } from 'react'
-import { redirect } from 'next/navigation'
+import { changeEmailSchema } from '@/schemas/userSchema'
 
 type ChangeEmailFormType = {
   email: string
@@ -30,7 +40,8 @@ const ChangeEmailForm = ({ email }: ChangeEmailFormType) => {
     if (lastResult?.status === 'success') {
       toast({
         title: '認証用のメールが送信されました。',
-        description: "メールに記載されているURLから変更手続きを完了させてください。",
+        description:
+          'メールに記載されているURLから変更手続きを完了させてください。',
         status: 'success',
         duration: 5000,
         isClosable: true,
@@ -62,7 +73,12 @@ const ChangeEmailForm = ({ email }: ChangeEmailFormType) => {
           placeholder="パスワードを入力して下さい"
           errors={fields.current_password.errors}
         />
-        <SubmitButton>変更する<Text as="span" fontSize="xs">（認証メール送信）</Text></SubmitButton>
+        <SubmitButton>
+          変更する
+          <Text as="span" fontSize="xs">
+            （認証メール送信）
+          </Text>
+        </SubmitButton>
       </Stack>
       <Input type="hidden" name="current_email" value={email} />
     </form>

--- a/next/src/components/organisms/form/ChangeEmailForm.tsx
+++ b/next/src/components/organisms/form/ChangeEmailForm.tsx
@@ -58,9 +58,9 @@ const ChangeEmailForm = ({ email }: ChangeEmailFormType) => {
         <InputWithLabel
           label="現在のパスワード"
           type="password"
-          name={fields.password.name}
+          name={fields.current_password.name}
           placeholder="パスワードを入力して下さい"
-          errors={fields.password.errors}
+          errors={fields.current_password.errors}
         />
         <SubmitButton>変更する<Text as="span" fontSize="xs">（認証メール送信）</Text></SubmitButton>
       </Stack>

--- a/next/src/components/organisms/form/ChangeEmailForm.tsx
+++ b/next/src/components/organisms/form/ChangeEmailForm.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Alert, AlertDescription, AlertIcon, Input, Stack, Text, useToast } from '@chakra-ui/react'
+import { useForm } from '@conform-to/react'
+import { parseWithZod } from '@conform-to/zod'
+import { useFormState } from 'react-dom'
+import SubmitButton from '../../atoms/SubmitButton'
+import InputWithLabel from '../../molecules/InputWithLabel'
+import { changeEmailSchema } from '@/schemas/userSchema'
+import { changeEmailAction } from '@/actions/changeEmailAction'
+import { useEffect } from 'react'
+import { redirect } from 'next/navigation'
+
+type ChangeEmailFormType = {
+  email: string
+}
+
+const ChangeEmailForm = ({ email }: ChangeEmailFormType) => {
+  const [lastResult, action] = useFormState(changeEmailAction, undefined)
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: changeEmailSchema(email) })
+    },
+  })
+
+  // 成功時のメッセージ
+  const toast = useToast()
+  useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast({
+        title: '認証用のメールが送信されました。',
+        description: "メールに記載されているURLから変更手続きを完了させてください。",
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      })
+      redirect('/setting')
+    }
+  }, [lastResult])
+
+  return (
+    <form id={form.id} onSubmit={form.onSubmit} action={action} noValidate>
+      {form.errors && (
+        <Alert status="error" my={4} borderRadius={4}>
+          <AlertIcon />
+          <AlertDescription>{form.errors[0]}</AlertDescription>
+        </Alert>
+      )}
+      <Stack spacing={6}>
+        <InputWithLabel
+          label="メールアドレス"
+          type="email"
+          name={fields.new_email.name}
+          placeholder="example@email.com"
+          errors={fields.new_email.errors}
+        />
+        <InputWithLabel
+          label="現在のパスワード"
+          type="password"
+          name={fields.password.name}
+          placeholder="パスワードを入力して下さい"
+          errors={fields.password.errors}
+        />
+        <SubmitButton>変更する<Text as="span" fontSize="xs">（認証メール送信）</Text></SubmitButton>
+      </Stack>
+      <Input type="hidden" name="current_email" value={email} />
+    </form>
+  )
+}
+
+export default ChangeEmailForm

--- a/next/src/components/organisms/form/ChangeProfileForm.tsx
+++ b/next/src/components/organisms/form/ChangeProfileForm.tsx
@@ -85,13 +85,6 @@ const ChangeProfileForm = ({ nickname, image }: ChangeProfileFormProps) => {
           prevImage={image}
         />
         <SubmitButton>変更を確定する</SubmitButton>
-        <TextIconLink
-          iconPosition="left"
-          iconName="FaChevronLeft"
-          href="/setting"
-        >
-          戻る
-        </TextIconLink>
       </Stack>
     </form>
   )

--- a/next/src/components/organisms/form/ChangeProfileForm.tsx
+++ b/next/src/components/organisms/form/ChangeProfileForm.tsx
@@ -22,7 +22,6 @@ import { useEffect } from 'react'
 import { useFormState } from 'react-dom'
 import { changeProfileAction } from '@/actions/changeProfileAction'
 import SubmitButton from '@/components/atoms/SubmitButton'
-import TextIconLink from '@/components/molecules/TextIconLink'
 import UploadAvatarForm from '@/components/molecules/UploadAvatarForm'
 import { changeProfileSchema } from '@/schemas/userSchema'
 

--- a/next/src/components/organisms/layout/Header.tsx
+++ b/next/src/components/organisms/layout/Header.tsx
@@ -3,10 +3,10 @@ import Logo from '/public/images/logo.svg'
 import NextLink from 'next/link'
 import CustomIcon from '../../atoms/CustomIcon'
 import SignoutButton from '../../atoms/SignoutButton'
-import { UserType } from '@/types/types'
+import { CurrentUserType } from '@/types/types'
 
 type HeaderProps = {
-  user: UserType
+  user: CurrentUserType
 }
 
 export default async function Header({ user }: HeaderProps) {

--- a/next/src/schemas/userSchema.ts
+++ b/next/src/schemas/userSchema.ts
@@ -8,23 +8,37 @@ export const signinSchema = z.object({
     .string({ required_error: 'パスワードを入力してください。' })
     .min(8, 'パスワードは8文字以上で入力して下さい。'),
 })
-export const registerSchema = z
-  .object({
-    email: z
-      .string({ required_error: 'メールアドレスを入力してください。' })
-      .email('メールアドレスの形式が正しくありません。'),
-    password: z
-      .string({ required_error: 'パスワードを入力してください。' })
-      .min(8, 'パスワードは8文字以上で入力して下さい。'),
-    password_confirmation: z
-      .string({ required_error: 'パスワードを入力してください。' })
-      .min(8, 'パスワードは8文字以上で入力して下さい。'),
-  })
-  .refine((data) => data.password === data.password_confirmation, {
-    message: 'パスワードが一致しません。',
-    path: ['password_confirmation'],
-  })
+
+export const registerSchema = z.object({
+  email: z
+    .string({ required_error: 'メールアドレスを入力してください。' })
+    .email('メールアドレスの形式が正しくありません。'),
+  password: z
+    .string({ required_error: 'パスワードを入力してください。' })
+    .min(8, 'パスワードは8文字以上で入力して下さい。'),
+  password_confirmation: z
+    .string({ required_error: 'パスワードを入力してください。' })
+    .min(8, 'パスワードは8文字以上で入力して下さい。'),
+})
+.refine((data) => data.password === data.password_confirmation, {
+  message: 'パスワードが一致しません。',
+  path: ['password_confirmation'],
+})
+
 export const changeProfileSchema = z.object({
   nickname: z.string().optional(),
   image: z.string().url('有効なURLを入力してください。').optional(),
 })
+
+export const changeEmailSchema = (currentEmail: string) => z.object({
+  new_email: z
+    .string({ required_error: 'メールアドレスを入力してください。' })
+    .email('メールアドレスの形式が正しくありません。')
+    .refine(
+      (newEmail) => newEmail !== currentEmail,
+      { message: '新しいメールアドレスは現在のメールアドレスと異なる必要があります。' }
+    ),
+  password: z
+    .string({ required_error: 'パスワードを入力してください。' })
+    .min(8, 'パスワードは8文字以上で入力して下さい。'),
+});

--- a/next/src/schemas/userSchema.ts
+++ b/next/src/schemas/userSchema.ts
@@ -9,36 +9,38 @@ export const signinSchema = z.object({
     .min(8, 'パスワードは8文字以上で入力して下さい。'),
 })
 
-export const registerSchema = z.object({
-  email: z
-    .string({ required_error: 'メールアドレスを入力してください。' })
-    .email('メールアドレスの形式が正しくありません。'),
-  password: z
-    .string({ required_error: 'パスワードを入力してください。' })
-    .min(8, 'パスワードは8文字以上で入力して下さい。'),
-  password_confirmation: z
-    .string({ required_error: 'パスワードを入力してください。' })
-    .min(8, 'パスワードは8文字以上で入力して下さい。'),
-})
-.refine((data) => data.password === data.password_confirmation, {
-  message: 'パスワードが一致しません。',
-  path: ['password_confirmation'],
-})
+export const registerSchema = z
+  .object({
+    email: z
+      .string({ required_error: 'メールアドレスを入力してください。' })
+      .email('メールアドレスの形式が正しくありません。'),
+    password: z
+      .string({ required_error: 'パスワードを入力してください。' })
+      .min(8, 'パスワードは8文字以上で入力して下さい。'),
+    password_confirmation: z
+      .string({ required_error: 'パスワードを入力してください。' })
+      .min(8, 'パスワードは8文字以上で入力して下さい。'),
+  })
+  .refine((data) => data.password === data.password_confirmation, {
+    message: 'パスワードが一致しません。',
+    path: ['password_confirmation'],
+  })
 
 export const changeProfileSchema = z.object({
   nickname: z.string().optional(),
   image: z.string().url('有効なURLを入力してください。').optional(),
 })
 
-export const changeEmailSchema = (currentEmail: string) => z.object({
-  new_email: z
-    .string({ required_error: 'メールアドレスを入力してください。' })
-    .email('メールアドレスの形式が正しくありません。')
-    .refine(
-      (newEmail) => newEmail !== currentEmail,
-      { message: '新しいメールアドレスは現在のメールアドレスと異なる必要があります。' }
-    ),
-  current_password: z
-    .string({ required_error: 'パスワードを入力してください。' })
-    .min(8, 'パスワードは8文字以上で入力して下さい。'),
-});
+export const changeEmailSchema = (currentEmail: string) =>
+  z.object({
+    new_email: z
+      .string({ required_error: 'メールアドレスを入力してください。' })
+      .email('メールアドレスの形式が正しくありません。')
+      .refine((newEmail) => newEmail !== currentEmail, {
+        message:
+          '新しいメールアドレスは現在のメールアドレスと異なる必要があります。',
+      }),
+    current_password: z
+      .string({ required_error: 'パスワードを入力してください。' })
+      .min(8, 'パスワードは8文字以上で入力して下さい。'),
+  })

--- a/next/src/schemas/userSchema.ts
+++ b/next/src/schemas/userSchema.ts
@@ -38,7 +38,7 @@ export const changeEmailSchema = (currentEmail: string) => z.object({
       (newEmail) => newEmail !== currentEmail,
       { message: '新しいメールアドレスは現在のメールアドレスと異なる必要があります。' }
     ),
-  password: z
+  current_password: z
     .string({ required_error: 'パスワードを入力してください。' })
     .min(8, 'パスワードは8文字以上で入力して下さい。'),
 });

--- a/next/src/store/store.ts
+++ b/next/src/store/store.ts
@@ -3,7 +3,7 @@ import {
   CategoryType,
   SouvenirSelectType,
   SouvenirCardType,
-  UserType,
+  CurrentUserType,
   PostType,
 } from '@/types/types'
 
@@ -61,8 +61,8 @@ export const useMyPostsStore = create<myPostsState>((set) => ({
 
 // ログイン中ユーザー
 type CurrentUserState = {
-  currentUser: UserType | null
-  setCurrentUser: (user: UserType) => void
+  currentUser: CurrentUserType | null
+  setCurrentUser: (user: CurrentUserType) => void
 }
 export const useCurrentUserStore = create<CurrentUserState>((set) => ({
   currentUser: null,

--- a/next/src/styles/theme/components/form.ts
+++ b/next/src/styles/theme/components/form.ts
@@ -26,4 +26,9 @@ export const Form = {
       },
     },
   },
+  FormLabel: {
+    baseStyle: {
+      fontWeight: "bold"
+    }
+  }
 }

--- a/next/src/styles/theme/components/form.ts
+++ b/next/src/styles/theme/components/form.ts
@@ -28,7 +28,7 @@ export const Form = {
   },
   FormLabel: {
     baseStyle: {
-      fontWeight: "bold"
-    }
-  }
+      fontWeight: 'bold',
+    },
+  },
 }

--- a/next/src/styles/theme/index.ts
+++ b/next/src/styles/theme/index.ts
@@ -33,6 +33,7 @@ const customTheme = extendTheme({
     Input: Form.Input,
     Select: Form.Select,
     Textarea: Form.Textarea,
+    FormLabel: Form.FormLabel,
     Tabs,
   },
   styles: {

--- a/next/src/types/types.ts
+++ b/next/src/types/types.ts
@@ -15,7 +15,7 @@ export type CurrentUserType = UserType & {
   isSignedIn: boolean
 }
 
-export type UserRequestType = "registration" | "change_email"
+export type UserRequestType = 'registration' | 'change_email'
 
 export type CategoryType = {
   id: number | ''

--- a/next/src/types/types.ts
+++ b/next/src/types/types.ts
@@ -15,7 +15,7 @@ export type CurrentUserType = UserType & {
   isSignedIn: boolean
 }
 
-export type UserRequestType = "registration" | "email_update"
+export type UserRequestType = "registration" | "change_email"
 
 export type CategoryType = {
   id: number | ''

--- a/next/src/types/types.ts
+++ b/next/src/types/types.ts
@@ -8,8 +8,14 @@ export type UserType = {
   alias_id: string
   nickname: string
   image: string
-  isSignedIn?: boolean
 }
+
+export type CurrentUserType = UserType & {
+  email: string
+  isSignedIn: boolean
+}
+
+export type UserRequestType = "registration" | "email_update"
 
 export type CategoryType = {
   id: number | ''

--- a/next/src/utils/fetchUserState.ts
+++ b/next/src/utils/fetchUserState.ts
@@ -4,13 +4,14 @@
 
 import { getUserTokens } from './getUserTokens'
 import { apiBaseUrl } from '@/constants/apiBaseUrl'
-import { UserType } from '@/types/types'
+import { CurrentUserType } from '@/types/types'
 
 export async function fetchUserState() {
-  let user: UserType = {
+  let user: CurrentUserType = {
     alias_id: '',
     nickname: '',
     image: '',
+    email: '',
     isSignedIn: false,
   }
   const tokens = await getUserTokens()

--- a/rails/app/controllers/api/v1/current/users_controller.rb
+++ b/rails/app/controllers/api/v1/current/users_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Current::UsersController < Api::V1::BaseController
   before_action :authenticate_user!
 
   def show
-    render json: UserResource.new(current_user).serialize
+    render json: UserResource.new(current_user, params: { include_email: true }).serialize
   end
 
   def posts

--- a/rails/app/controllers/api/v1/user/confirmations_controller.rb
+++ b/rails/app/controllers/api/v1/user/confirmations_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::User::ConfirmationsController < Api::V1::BaseController
         message: "メールアドレスの認証に成功しました",
         access_token: token["access-token"],
         client: token["client"],
-        uid: token["uid"],
+        uid: token["uid"]
         }, status: :ok
 
     rescue StandardError => e

--- a/rails/app/controllers/api/v1/user/confirmations_controller.rb
+++ b/rails/app/controllers/api/v1/user/confirmations_controller.rb
@@ -1,17 +1,29 @@
 class Api::V1::User::ConfirmationsController < Api::V1::BaseController
   def update
-    user = User.find_by(confirmation_token: params[:confirmation_token])
-    return render json: { message: "ユーザーが見つかりませんでした。再度会員登録を行ってください。" }, status: :not_found if user.nil?
-    return render json: { message: "このユーザーはすでに認証済みです。" }, status: :bad_request if user.confirmed?
+    begin
+      user = User.find_by(confirmation_token: params[:confirmation_token])
+      return render json: { message: "ユーザーが見つかりませんでした。再度会員登録を行ってください。" }, status: :not_found if user.nil?
+      return render json: { message: "このメールアドレスはすでに認証済みです。" }, status: :bad_request if user.confirmed? && !user.pending_reconfirmation?
 
-    user.update!(confirmed_at: Time.current)
+      if user.pending_reconfirmation?
+        user.skip_reconfirmation!
+        user.email = user.unconfirmed_email
+        user.unconfirmed_email = nil
+      end
 
-    token = user.create_new_auth_token
-    render json: {
-      message: "ユーザー認証に成功しました。",
-      access_token: token["access-token"],
-      client: token["client"],
-      uid: token["uid"]
-      }, status: :ok
+      user.confirmed_at = Time.current
+      user.save!
+
+      token = user.create_new_auth_token
+      render json: {
+        message: "メールアドレスの認証に成功しました",
+        access_token: token["access-token"],
+        client: token["client"],
+        uid: token["uid"],
+        }, status: :ok
+
+    rescue StandardError => e
+      render json: { message: "サーバーエラーが発生しました。時間をおいてから再度お試しください。" }, status: :unprocessable_entity
+    end
   end
 end

--- a/rails/app/controllers/api/v1/user/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/user/registrations_controller.rb
@@ -1,4 +1,19 @@
 class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  protected
+  # パスワードとメールアドレスの変更以外はパスワード入力なしで変更可能にする（devise_token_authオーバーライド）
+  def resource_update_method
+    if DeviseTokenAuth.check_current_password_before_update == :attributes
+      'update_with_password'
+    else
+      if account_update_params.key?(:password) || account_update_params.key?(:email) || account_update_params.key?(:current_password)
+        'update_with_password'
+        # binding.pry
+      else
+        'update'
+      end
+    end
+  end
+
   private
 
   def sign_up_params

--- a/rails/app/controllers/api/v1/user/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/user/registrations_controller.rb
@@ -1,5 +1,14 @@
 class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  def update
+    if @resource.is_email_conflict?(account_update_params[:email])
+      return render json: { status: 'error', errors: { full_messages: [ "このメールアドレスはすでに使用されています。" ] } }, status: :conflict
+    end
+    super
+  end
+
   protected
+
   # パスワードとメールアドレスの変更以外はパスワード入力なしで変更可能にする（devise_token_authオーバーライド）
   def resource_update_method
     if DeviseTokenAuth.check_current_password_before_update == :attributes
@@ -7,7 +16,6 @@ class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsCo
     else
       if account_update_params.key?(:password) || account_update_params.key?(:email) || account_update_params.key?(:current_password)
         'update_with_password'
-        # binding.pry
       else
         'update'
       end

--- a/rails/app/controllers/api/v1/user/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/user/registrations_controller.rb
@@ -1,9 +1,12 @@
 class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsController
 
   def update
-    if @resource.is_email_conflict?(account_update_params[:email])
-      return render json: { status: 'error', errors: { full_messages: [ "このメールアドレスはすでに使用されています。" ] } }, status: :conflict
-    end
+    # 現在のメールアドレスと同じ場合
+    return render json: { status: 'error', errors: { full_messages: [ "新しいメールアドレスは現在のメールアドレスと異なる必要があります。" ] } }, status: :unprocessable_entity if @resource.email == account_update_params[:email]
+
+    # 他のメールアドレスと重複している場合
+    return render json: { status: 'error', errors: { full_messages: [ "このメールアドレスはすでに使用されています。" ] } }, status: :conflict if User.exists?(email: account_update_params[:email])
+
     super
   end
 

--- a/rails/app/controllers/api/v1/user/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/user/registrations_controller.rb
@@ -1,11 +1,10 @@
 class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsController
-
   def update
     # 現在のメールアドレスと同じ場合
-    return render json: { status: 'error', errors: { full_messages: [ "新しいメールアドレスは現在のメールアドレスと異なる必要があります。" ] } }, status: :unprocessable_entity if @resource.email == account_update_params[:email]
+    return render json: { status: "error", errors: { full_messages: [ "新しいメールアドレスは現在のメールアドレスと異なる必要があります。" ] } }, status: :unprocessable_entity if @resource.email == account_update_params[:email]
 
     # 他のメールアドレスと重複している場合
-    return render json: { status: 'error', errors: { full_messages: [ "このメールアドレスはすでに使用されています。" ] } }, status: :conflict if User.exists?(email: account_update_params[:email])
+    return render json: { status: "error", errors: { full_messages: [ "このメールアドレスはすでに使用されています。" ] } }, status: :conflict if User.exists?(email: account_update_params[:email])
 
     super
   end
@@ -15,12 +14,12 @@ class  Api::V1::User::RegistrationsController < DeviseTokenAuth::RegistrationsCo
   # パスワードとメールアドレスの変更以外はパスワード入力なしで変更可能にする（devise_token_authオーバーライド）
   def resource_update_method
     if DeviseTokenAuth.check_current_password_before_update == :attributes
-      'update_with_password'
+      "update_with_password"
     else
       if account_update_params.key?(:password) || account_update_params.key?(:email) || account_update_params.key?(:current_password)
-        'update_with_password'
+        "update_with_password"
       else
-        'update'
+        "update"
       end
     end
   end

--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < Devise::Mailer
+  # def confirmation_on_create_instructions(record, token, opts = {})
+  #   pp 'ああああああああああああああああああああああああああああ'
+  #   @token = token
+  #   devise_mail(record, :confirmation_on_create_instructions, opts)
+  # end
+
+  def email_change_confirmation_instructions(record, token, opts = {})
+    pp 'いいいいいいいいいいいいいいいいいいいいいいいいい'
+    @token = token
+    devise_mail(record, :email_change_confirmation_instructions, opts)
+  end
+end

--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -1,12 +1,5 @@
 class UserMailer < Devise::Mailer
-  # def confirmation_on_create_instructions(record, token, opts = {})
-  #   pp 'ああああああああああああああああああああああああああああ'
-  #   @token = token
-  #   devise_mail(record, :confirmation_on_create_instructions, opts)
-  # end
-
   def email_change_confirmation_instructions(record, token, opts = {})
-    pp 'いいいいいいいいいいいいいいいいいいいいいいいいい'
     @token = token
     devise_mail(record, :email_change_confirmation_instructions, opts)
   end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -34,6 +34,15 @@ class User < ActiveRecord::Base
     end
   end
 
+  # 変更後のメールアドレスが他のメールアドレスと重複しているか確認
+  def is_email_conflict?(email)
+    if pending_reconfirmation?
+      return User.exists?(email: email)
+    else
+      return false
+    end
+  end
+
   private
 
   # nickname が空文字の場合は更新をキャンセル
@@ -42,4 +51,5 @@ class User < ActiveRecord::Base
       self.nickname = nickname_was # 以前の値に戻す
     end
   end
+
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ActiveRecord::Base
     generate_confirmation_token! unless @raw_confirmation_token
 
     # fall back to "default" config name
-    opts[:client_config] ||= 'default'
+    opts[:client_config] ||= "default"
     opts[:to] = unconfirmed_email if pending_reconfirmation?
     opts[:redirect_url] ||= DeviseTokenAuth.default_confirm_success_url
 
@@ -42,5 +42,4 @@ class User < ActiveRecord::Base
       self.nickname = nickname_was # 以前の値に戻す
     end
   end
-
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -17,6 +17,23 @@ class User < ActiveRecord::Base
 
   validates :image, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "は有効なURLを入力してください。" }, allow_blank: true
 
+
+  # メールアドレス変更時は別のテンプレートを使用するように上書き
+  def send_confirmation_instructions(opts = {})
+    generate_confirmation_token! unless @raw_confirmation_token
+
+    # fall back to "default" config name
+    opts[:client_config] ||= 'default'
+    opts[:to] = unconfirmed_email if pending_reconfirmation?
+    opts[:redirect_url] ||= DeviseTokenAuth.default_confirm_success_url
+
+    if pending_reconfirmation?
+      send_devise_notification(:email_change_confirmation_instructions, @raw_confirmation_token, opts)
+    else
+      send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+    end
+  end
+
   protected
 
   # パスワードの変更以外はパスワード入力なしで変更可能にする

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -34,15 +34,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  # 変更後のメールアドレスが他のメールアドレスと重複しているか確認
-  def is_email_conflict?(email)
-    if pending_reconfirmation?
-      return User.exists?(email: email)
-    else
-      return false
-    end
-  end
-
   private
 
   # nickname が空文字の場合は更新をキャンセル

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -34,17 +34,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  protected
-
-  # パスワードの変更以外はパスワード入力なしで変更可能にする
-  def update_resource(resource, params)
-    if params[:password].blank? && params[:password_confirmation].blank?
-      resource.update_without_password(params)
-    else
-      super
-    end
-  end
-
   private
 
   # nickname が空文字の場合は更新をキャンセル

--- a/rails/app/resources/user_resource.rb
+++ b/rails/app/resources/user_resource.rb
@@ -2,4 +2,5 @@ class UserResource
   include Alba::Resource
 
   attributes :alias_id, :nickname, :image
+  attributes :email, if: proc { params[:include_email] }
 end

--- a/rails/app/views/devise/mailer/confirmation_instructions.erb
+++ b/rails/app/views/devise/mailer/confirmation_instructions.erb
@@ -7,19 +7,6 @@
   <%= t '.confirm_link_msg' %> 
 </p>
 
-<p>URL：<%= link_to "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}", "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}", target: :_blank, rel: "noopener noreferrer" %></p>
+<p>URL：<%= link_to "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=registration", "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=registration", target: :_blank, rel: "noopener noreferrer" %></p>
 
-<br><br>
-
-<p>
-  ※<%= t 'devise.mailer.caution_note.send_only_msg' %><br>
-  ※<%= t 'devise.mailer.caution_note.misdelivery_msg' %>
-</p>
-
-<br>
-<hr>
-
-<p>
-  Bon Boyage Collection<br>
-  <%= link_to "#{Settings.front_domain}", "#{Settings.front_domain}", target: :_blank, rel: "noopener noreferrer" %>
-</p>
+<%= render 'devise/mailer/shared/email_footer' %>

--- a/rails/app/views/devise/mailer/email_change_confirmation_instructions.erb
+++ b/rails/app/views/devise/mailer/email_change_confirmation_instructions.erb
@@ -1,0 +1,12 @@
+<p>※<%= t 'devise.mailer.caution_note.for_registered_mail_msg' %></p>
+
+<h2><%= t '.title' %></h2>
+
+<p>
+  <%= t '.accept_change_request_msg' %><br>
+  <%= t '.request_confirm_link_msg' %>
+</p>
+
+<p>URL：<%= link_to "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=change_email", "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=email_update", target: :_blank, rel: "noopener noreferrer" %></p>
+
+<%= render 'devise/mailer/shared/email_footer' %>

--- a/rails/app/views/devise/mailer/email_change_confirmation_instructions.erb
+++ b/rails/app/views/devise/mailer/email_change_confirmation_instructions.erb
@@ -7,6 +7,6 @@
   <%= t '.request_confirm_link_msg' %>
 </p>
 
-<p>URL：<%= link_to "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=change_email", "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=email_update", target: :_blank, rel: "noopener noreferrer" %></p>
+<p>URL：<%= link_to "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=change_email", "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}&request_action=change_email", target: :_blank, rel: "noopener noreferrer" %></p>
 
 <%= render 'devise/mailer/shared/email_footer' %>

--- a/rails/app/views/devise/mailer/shared/_email_footer.erb
+++ b/rails/app/views/devise/mailer/shared/_email_footer.erb
@@ -1,0 +1,14 @@
+<br><br>
+
+<p>
+  ※<%= t 'devise.mailer.caution_note.send_only_msg' %><br>
+  ※<%= t 'devise.mailer.caution_note.misdelivery_msg' %>
+</p>
+
+<br>
+<hr>
+
+<p>
+  Bon Boyage Collection<br>
+  <%= link_to "#{Settings.front_domain}", "#{Settings.front_domain}", target: :_blank, rel: "noopener noreferrer" %>
+</p>

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = "bon.boyage.collection@gmail.com"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'UserMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = "bon.boyage.collection@gmail.com"
 
   # Configure the class responsible to send e-mails.
-  config.mailer = 'UserMailer'
+  config.mailer = "UserMailer"
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/rails/config/initializers/devise_token_auth.rb
+++ b/rails/config/initializers/devise_token_auth.rb
@@ -57,10 +57,10 @@ DeviseTokenAuth.setup do |config|
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!
-  # config.enable_standard_devise_support = false
+  # config.enable_standard_devise_support = true
 
   # By default DeviseTokenAuth will not send confirmation email, even when including
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
-  # config.send_confirmation_email = true
+  config.send_confirmation_email = true
 end

--- a/rails/config/locales/devise.ja.yml
+++ b/rails/config/locales/devise.ja.yml
@@ -42,6 +42,7 @@ ja:
       validate_sign_up_params: "リクエストボディに適切なアカウント新規登録データを送信してください。"
       validate_account_update_params: "リクエストボディに適切なアカウント更新のデータを送信してください。"
       not_email: "は有効ではありません"
+      invalid: "が正しくありません。"
   devise:
     mailer:
       confirmation_instructions:

--- a/rails/config/locales/devise.ja.yml
+++ b/rails/config/locales/devise.ja.yml
@@ -51,7 +51,7 @@ ja:
         confirm_link_msg: "以下のリンクよりメールアドレスを認証してください。"
         confirm_account_link: "メールアドレスを認証する"
       email_change_confirmation_instructions:
-        subject: "【Bon Boyage Collection】メールアドレス確認のご案内"
+        subject: "【Bon Boyage Collection】メールアドレス変更手続きのご案内"
         title: "メールアドレス変更手続きを完了させてください。"
         accept_change_request_msg: "メールアドレス変更のお申し込みを承りました。"
         request_confirm_link_msg: "以下のリンクよりメールアドレスを認証してください。"

--- a/rails/config/locales/devise.ja.yml
+++ b/rails/config/locales/devise.ja.yml
@@ -49,6 +49,11 @@ ja:
         thankyou_msg: "この度は、会員登録いただきありがとうございます。"
         confirm_link_msg: "以下のリンクよりメールアドレスを認証してください。"
         confirm_account_link: "メールアドレスを認証する"
+      email_change_confirmation_instructions:
+        subject: "【Bon Boyage Collection】メールアドレス確認のご案内"
+        title: "メールアドレス変更手続きを完了させてください。"
+        accept_change_request_msg: "メールアドレス変更のお申し込みを承りました。"
+        request_confirm_link_msg: "以下のリンクよりメールアドレスを認証してください。"
       reset_password_instructions:
         request_reset_link_msg: "パスワード変更のリクエストが送信されました。下記のリンクからパスワードの変更ができます。"
         password_change_link: "パスワードを変更する"

--- a/rails/spec/factories/user.rb
+++ b/rails/spec/factories/user.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Name.name }
     sequence(:email) { |n| "#{n}_" + Faker::Internet.email }
     password { Faker::Internet.password(min_length: 8) }
+    nickname { Faker::Name.name }
+    image { "https://example.com/image.jpg" }
     confirmed_at { Time.current }
   end
 end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe User, type: :model do
         expect(user_with_short_password).to be_invalid
         expect(user_with_short_password.errors[:password]).not_to be_empty
       end
+
+      it "プロフィール画像が正しい形式でない場合、バリデーションに失敗する" do
+        user_with_invalid_image = build(:user, image: "invalid_url")
+        expect(user_with_invalid_image).to be_invalid
+        expect(user_with_invalid_image.errors[:image]).not_to be_empty
+      end
     end
   end
 end

--- a/rails/spec/requests/api/v1/user/current/users_spec.rb
+++ b/rails/spec/requests/api/v1/user/current/users_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "ログイン中のユーザー情報取得", type: :request do
       it "正常にレコードを取得できる" do
         get_request
         res = JSON.parse(response.body)
-        expect(res.keys).to eq [ "alias_id", "nickname", "image" ]
+        expect(res.keys).to eq [ "alias_id", "nickname", "image", "email" ]
         expect(response).to have_http_status(:ok)
       end
     end

--- a/rails/spec/requests/api/v1/user/registration_spec.rb
+++ b/rails/spec/requests/api/v1/user/registration_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'ユーザー登録', type: :request do
       it 'メール認証が成功し、ユーザーが確認済みになる' do
         patch_request
         expect(response).to have_http_status(:ok)
-        expect(json['message']).to eq('ユーザー認証に成功しました。')
+        expect(json['message']).to eq('メールアドレスの認証に成功しました')
 
         user.reload
         expect(user.confirmed?).to be true
@@ -88,7 +88,7 @@ RSpec.describe 'ユーザー登録', type: :request do
           # 2回目は認証失敗
           patch "/api/v1/user/confirmations", params: { confirmation_token: token }
           expect(response).to have_http_status(:bad_request)
-          expect(json['message']).to eq('このユーザーはすでに認証済みです。')
+          expect(json['message']).to eq('このメールアドレスはすでに認証済みです。')
         end
       end
 

--- a/rails/spec/requests/api/v1/user/update_spec.rb
+++ b/rails/spec/requests/api/v1/user/update_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'プロフィール変更', type: :request do
             patch_request
             expect(response).to have_http_status(:unprocessable_entity)
             expect(json['status']).to eq('error')
-            expect(json['errors']['full_messages']).to eq(['現在のパスワードを入力してください'])
+            expect(json['errors']['full_messages']).to eq([ '現在のパスワードを入力してください' ])
           end
         end
 
@@ -119,7 +119,7 @@ RSpec.describe 'プロフィール変更', type: :request do
             patch_request
             expect(response).to have_http_status(:unprocessable_entity)
             expect(json['status']).to eq('error')
-            expect(json['errors']['full_messages']).to eq(['現在のパスワードが正しくありません。'])
+            expect(json['errors']['full_messages']).to eq([ '現在のパスワードが正しくありません。' ])
 
             user.reload
             expect(user.unconfirmed_email).to eq(nil)
@@ -138,7 +138,7 @@ RSpec.describe 'プロフィール変更', type: :request do
             patch_request
             expect(response).to have_http_status(:unprocessable_entity)
             expect(json['status']).to eq('error')
-            expect(json['errors']['full_messages']).to eq(['新しいメールアドレスは現在のメールアドレスと異なる必要があります。'])
+            expect(json['errors']['full_messages']).to eq([ '新しいメールアドレスは現在のメールアドレスと異なる必要があります。' ])
 
             user.reload
             expect(user.unconfirmed_email).to eq(nil)
@@ -158,7 +158,7 @@ RSpec.describe 'プロフィール変更', type: :request do
             patch_request
             expect(response).to have_http_status(:conflict)
             expect(json['status']).to eq('error')
-            expect(json['errors']['full_messages']).to eq(['このメールアドレスはすでに使用されています。'])
+            expect(json['errors']['full_messages']).to eq([ 'このメールアドレスはすでに使用されています。' ])
 
             user.reload
             expect(user.unconfirmed_email).to eq(nil)
@@ -166,7 +166,6 @@ RSpec.describe 'プロフィール変更', type: :request do
         end
       end
     end
-
   end
 
   describe 'メール認証' do
@@ -219,6 +218,5 @@ RSpec.describe 'プロフィール変更', type: :request do
         end
       end
     end
-
   end
 end

--- a/rails/spec/requests/api/v1/user/update_spec.rb
+++ b/rails/spec/requests/api/v1/user/update_spec.rb
@@ -1,67 +1,224 @@
 require 'rails_helper'
 
 RSpec.describe 'プロフィール変更', type: :request do
-  let(:user) { create(:user, nickname: "ニックネーム", image: "http://example.com/image.jpg") }
+  let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
   let(:params) { {} }
 
   describe 'PATCH /api/v1/auth' do
     subject(:patch_request) { patch('/api/v1/auth', params:, headers:) }
 
-    context '成功' do
+    context "表示名・プロフィール画像の変更" do
+      context '成功' do
+        let(:params) do
+          {
+            nickname: '新しいニックネーム',
+            image: 'http://example.com/new-image.jpg'
+          }
+        end
+
+        it '正しい情報が送信された場合、プロフィールが更新される' do
+          patch_request
+          expect(response).to have_http_status(:ok)
+          expect(json['data']['nickname']).to eq(params[:nickname])
+          expect(json['data']['image']).to eq(params[:image])
+
+          user.reload
+          expect(user.nickname).to eq(params[:nickname])
+          expect(user.image).to eq(params[:image])
+        end
+      end
+
+      context '失敗' do
+        context '認証情報がない場合' do
+          let(:headers) { {} }
+
+          it '422エラーを返す' do
+            patch_request
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json['errors']).not_to be_empty
+          end
+        end
+
+        context '画像URLの形式が正しくない場合' do
+          let(:params) { { nickname: user.nickname, image: 'invalid_url' } }
+
+          it '422エラーを返す' do
+            patch_request
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json['errors']).not_to be_empty
+          end
+        end
+      end
+
+      context 'nicknameが空文字の場合' do
+        let(:params) { { nickname: '', image: user.image } }
+
+        it '表示名は変更されない' do
+          prev_nickname = user.nickname
+          patch_request
+          expect(response).to have_http_status(:ok)
+          expect(json['data']['nickname']).to eq(prev_nickname)
+
+          user.reload
+          expect(user.nickname).to eq(prev_nickname)
+        end
+      end
+    end
+
+    context "メールアドレスの変更" do
+      context '成功' do
+        let(:params) do
+          {
+            email: "new-email@example.com",
+            current_password: user.password
+          }
+        end
+
+        it '正しく情報が入力された場合、unconfirmed_emailにメールアドレスが保存され、確認メールが送信される' do
+          patch_request
+          expect(response).to have_http_status(:ok)
+          expect(json['status']).to eq('success')
+
+          user.reload
+          expect(user.unconfirmed_email).to eq(params[:email])
+
+          # メールが送信されていることを確認
+          mail = ActionMailer::Base.deliveries.last
+          expect(mail.to).to include(params[:email])
+          expect(mail.subject).to eq('【Bon Boyage Collection】メールアドレス変更手続きのご案内')
+        end
+      end
+
+      context '失敗' do
+        context '現在のパスワードがない場合' do
+          let(:params) do
+            {
+              email: "new-email@example.com",
+              current_password: ''
+            }
+          end
+
+          it '422エラーになる' do
+            patch_request
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json['status']).to eq('error')
+            expect(json['errors']['full_messages']).to eq(['現在のパスワードを入力してください'])
+          end
+        end
+
+        context '現在のパスワードが間違っていた場合' do
+          let(:params) do
+            {
+              email: "new-email@example.com",
+              current_password: 'wrongpassword'
+            }
+          end
+
+          it '422エラーになる' do
+            patch_request
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json['status']).to eq('error')
+            expect(json['errors']['full_messages']).to eq(['現在のパスワードが正しくありません。'])
+
+            user.reload
+            expect(user.unconfirmed_email).to eq(nil)
+          end
+        end
+
+        context 'メールアドレスが現在のものと同じ場合' do
+          let(:params) do
+            {
+              email: user.email,
+              current_password: user.password
+            }
+          end
+
+          it '422エラーになる' do
+            patch_request
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json['status']).to eq('error')
+            expect(json['errors']['full_messages']).to eq(['新しいメールアドレスは現在のメールアドレスと異なる必要があります。'])
+
+            user.reload
+            expect(user.unconfirmed_email).to eq(nil)
+          end
+        end
+
+        context 'メールアドレスが他のユーザーと重複している場合' do
+          let(:other_user) { create(:user, email: "other-email@example.com") }
+          let(:params) do
+            {
+              email: other_user.email,
+              current_password: user.password
+            }
+          end
+
+          it '409エラーになる' do
+            patch_request
+            expect(response).to have_http_status(:conflict)
+            expect(json['status']).to eq('error')
+            expect(json['errors']['full_messages']).to eq(['このメールアドレスはすでに使用されています。'])
+
+            user.reload
+            expect(user.unconfirmed_email).to eq(nil)
+          end
+        end
+      end
+    end
+
+  end
+
+  describe 'メール認証' do
+    subject(:patch_request) { patch('/api/v1/auth', params:, headers:) }
+
+    context 'メールアドレス変更' do
       let(:params) do
         {
-          nickname: '新しいニックネーム',
-          image: 'http://example.com/new-image.jpg'
+          email: "new-email@example.com",
+          current_password: user.password
         }
       end
+      let(:token) { user.confirmation_token }
+      subject(:confirmation_request) { patch('/api/v1/user/confirmations', params: { confirmation_token: token }) }
 
-      it '正しい情報が送信された場合、プロフィールが更新される' do
+      before do
         patch_request
-        expect(response).to have_http_status(:ok)
-        expect(json['data']['nickname']).to eq(params[:nickname])
-        expect(json['data']['image']).to eq(params[:image])
-
         user.reload
-        expect(user.nickname).to eq(params[:nickname])
-        expect(user.image).to eq(params[:image])
       end
-    end
 
-    context '失敗' do
-      context '認証情報がない場合' do
-        let(:headers) { {} }
+      context '成功' do
+        it 'メールアドレスが認証される' do
+          confirmation_request
+          expect(response).to have_http_status(:ok)
 
-        it '422エラーを返す' do
-          patch_request
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(json['errors']).not_to be_empty
+          user.reload
+          expect(user.email).to eq(params[:email])
         end
       end
 
-      context '画像URLの形式が正しくない場合' do
-        let(:params) { { nickname: user.nickname, image: 'invalid_url' } }
+      context '失敗' do
+        context '無効なトークンの場合' do
+          let(:token) { 'invalid_token' }
 
-        it '422エラーを返す' do
-          patch_request
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(json['errors']).not_to be_empty
+          it '404エラーを返す' do
+            confirmation_request
+            expect(response).to have_http_status(:not_found)
+            expect(json['message']).to eq('ユーザーが見つかりませんでした。再度会員登録を行ってください。')
+          end
+        end
+
+        context 'confirmation_tokenが空の場合' do
+          let(:token) { nil }
+
+          it '404エラーを返す' do
+            confirmation_request
+            expect(response).to have_http_status(:not_found)
+            expect(json['message']).to eq('ユーザーが見つかりませんでした。再度会員登録を行ってください。')
+          end
         end
       end
     end
 
-    context 'nicknameが空文字の場合' do
-      let(:params) { { nickname: '', image: user.image } }
-
-      it '表示名は変更されない' do
-        prev_nickname = user.nickname
-        patch_request
-        expect(response).to have_http_status(:ok)
-        expect(json['data']['nickname']).to eq(prev_nickname)
-
-        user.reload
-        expect(user.nickname).to eq(prev_nickname)
-      end
-    end
   end
 end


### PR DESCRIPTION
### 対応内容
- [ ] メール変更機能の追加、変更ページの作成
- [ ] deviseのconfirmabale機能によるメール認証機能の実装
- [ ] 会員登録時とメール変更時のメールのテンプレートを分ける（devise_token_authの記述をオーバーライド）
- [ ] current_userのレスポンスにemailを含める（＋型定義修正）
- [ ] メールアドレス変更機能のrspec作成