### PR TITLE
fix: 通貨選択の修正

### DIFF
--- a/next/src/app/api/autocomplete/route.ts
+++ b/next/src/app/api/autocomplete/route.ts
@@ -10,6 +10,7 @@ export async function GET(req: Request) {
   }
 
   const apiKey = process.env.GOOGLE_MAP_API_KEY
+  console.log(apiKey)
   const url = `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(
     query,
   )}&key=${apiKey}&sessiontoken=${sessionToken}&types=establishment&language=ja`

--- a/rails/app/controllers/api/v1/posts_controller.rb
+++ b/rails/app/controllers/api/v1/posts_controller.rb
@@ -23,6 +23,10 @@ class Api::V1::PostsController < Api::V1::BaseController
       return
     end
 
+    # 金額の入力がなく、通貨だけの場合、通貨は登録しない
+    processed_params = post_params
+    processed_params[:currency] = nil if processed_params[:price].present?
+
     post = current_user.posts.build(post_params)
     post.souvenir = souvenir
     if post.save

--- a/rails/app/models/post.rb
+++ b/rails/app/models/post.rb
@@ -12,7 +12,6 @@ class Post < ApplicationRecord
 
   validates :souvenir_id, presence: { message: "を選択してください。" }, uniqueness: { scope: :user_id, message: "はすでに記録済みです。" }
   validates :rating, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 5, message: "は1以上5以下の値で入力してください。" }, allow_nil: true
-  validates :price, presence: { message: "を入力してください。" }, if: -> { currency.present? }
   validates :currency, presence: { message: "を選択してください。" }, if: -> { price.present? }
   validate :price_range_validation
 

--- a/rails/spec/models/post_spec.rb
+++ b/rails/spec/models/post_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Post, type: :model do
         expect(created_post.alias_id).to be_present
         expect(created_post.alias_id).to be_a(String)
       end
+
+      it "currencyがあるが、priceがない場合、バリデーションに失敗しない" do
+        post.price = nil
+        expect(post).to be_valid
+        expect(post.errors).to be_empty
+      end
     end
 
     context "失敗" do
@@ -57,12 +63,6 @@ RSpec.describe Post, type: :model do
         post.currency = nil
         expect(post).to be_invalid
         expect(post.errors.full_messages).to include('通貨を選択してください。')
-      end
-
-      it "currencyがあるが、priceがない場合、バリデーションに失敗する" do
-        post.price = nil
-        expect(post).to be_invalid
-        expect(post.errors.full_messages).to include('金額を入力してください。')
       end
 
       it "priceが小数点第4位以下の場合、バリデーションに失敗する" do

--- a/rails/spec/requests/api/v1/posts_spec.rb
+++ b/rails/spec/requests/api/v1/posts_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe "投稿", type: :request do
           expect(json['errors']).to eq [ "このお土産はすでに記録済みです。" ]
         end
       end
+
+      context "currencyがあるが、priceがない場合" do
+        let(:params) { super().merge(price: '') }
+        it 'currencyはnilで登録される' do
+          expect { post_request }.to change { Post.count }.by(1)
+          expect(response).to have_http_status(:ok)
+          expect(json['price']).to eq('')
+        end
+      end
     end
 
     context '未認証のユーザーの場合' do


### PR DESCRIPTION
### 対応内容
- [ ] 金額入力時、通貨がデータベースに登録されないようにする（初期値がJPYのため）
- [ ] 上記のテストコード